### PR TITLE
Agregar badge de recorrido

### DIFF
--- a/lib/widgets/common/custom_badge.dart
+++ b/lib/widgets/common/custom_badge.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class CustomBadge extends StatelessWidget {
+  final String text;
+
+  const CustomBadge({ super.key, required this.text });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: Colors.red, //TODO: agregar el color del theme.
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.labelSmall,
+      ),
+    );
+  }
+}

--- a/lib/widgets/travel/travel_detail_widget.dart
+++ b/lib/widgets/travel/travel_detail_widget.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+
+import 'package:shipping_pilot/widgets/widgets.dart';
+
 import 'package:shipping_pilot/models/models.dart';
 
 class TravelDetailWidget extends StatelessWidget {
@@ -22,6 +25,8 @@ class TravelDetailWidget extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                TravelStatusBadge(status: travel.status),
+                const SizedBox( height: 4 ),
                 Text(
                   '${travel.stats.packagesCount} paquete(s), ${travel.stats.visitsCount} visita(s)',
                   style: Theme.of(context).textTheme.bodyMedium
@@ -33,7 +38,7 @@ class TravelDetailWidget extends StatelessWidget {
                 ),
               ],
             ),
-          )
+          ),
         ],
       ),
     );

--- a/lib/widgets/travel/travel_status_badge_widget.dart
+++ b/lib/widgets/travel/travel_status_badge_widget.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import 'package:shipping_pilot/widgets/widgets.dart';
+
+class TravelStatusBadge extends StatelessWidget {
+  final String status;
+ 
+  const TravelStatusBadge({super.key, required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+
+    final statusText = {
+      'new': 'En espera de inicio',
+      'in_progress': 'En curso',
+      'finished': 'Finalizado',
+    };
+    
+    return CustomBadge(text: statusText[status] ?? '');
+  }
+}

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,9 +1,11 @@
 /* common */
 export 'package:shipping_pilot/widgets/common/appbar_widget.dart';
+export 'package:shipping_pilot/widgets/common/custom_badge.dart';
 export 'package:shipping_pilot/widgets/common/sidebar_widget.dart';
 
 /* travel */
 export 'package:shipping_pilot/widgets/travel/travel_detail_widget.dart';
+export 'package:shipping_pilot/widgets/travel/travel_status_badge_widget.dart';
 
 /* vehicle */
 export 'package:shipping_pilot/widgets/vehicle/vehicle_detail_widget.dart';


### PR DESCRIPTION
Cambios realizados:

- Cree el widget CustomBadge, un widget genérico para crear badges como el TravelStatusBadge .
- Cree el widget TravelStatusBadge, un widget para visualizar el estado del recorrido.

![image](https://github.com/NGiudi/shipping_pilot_app/assets/33135912/e85d5ed4-e6bc-486f-878a-08d334a45757)
